### PR TITLE
Fix client info display on form submissions page

### DIFF
--- a/src/views/admin/forms/submissions.ejs
+++ b/src/views/admin/forms/submissions.ejs
@@ -57,10 +57,13 @@
               <% submissions.forEach(submission => { %>
                 <tr>
                   <td>
-                    <% if (submission.client) { %>
-                      <%= submission.client.name %>
+                    <% if (submission.client_name) { %>
+                      <%= submission.client_name %>
+                      <% if (submission.client_email) { %><br>
+                        <small class="text-muted"><%= submission.client_email %></small>
+                      <% } %>
                     <% } else { %>
-                      <span class="text-muted">Unknown Client</span>
+                      Anonymous
                     <% } %>
                   </td>
                   <td><%= new Date(submission.submitted_at).toLocaleString() %></td>


### PR DESCRIPTION
## Summary
- fix client name display on form submissions list

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6853097bf918832d86d7dcc801ca3873