### PR TITLE
Display Add Question button on form creation page

### DIFF
--- a/src/views/admin/forms/create.ejs
+++ b/src/views/admin/forms/create.ejs
@@ -794,17 +794,12 @@
   }
   
   .add-between-hint {
-    display: none;
+    display: block;
     position: absolute;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
     z-index: 2;
-  }
-  
-  .add-question-between:hover .add-between-hint,
-  .add-question-between:focus-within .add-between-hint {
-    display: block;
   }
   
   .add-question-between:hover::before {


### PR DESCRIPTION
## Summary
- ensure the "Add Question" button is always visible when creating forms

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6853189b79ec8325af7ee917b481486a